### PR TITLE
resolves #476 Using the same color syntax to convert in HTML and PDF …

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -2467,8 +2467,8 @@ class Converter < ::Prawn::Document
         end
     else
         img_dir = resolve_imagesdir(doc = node.document)
-    end if
-    image_path ||= node.attr 'target'
+    end
+    image_path ||= (node.attr 'target', nil, false)
     image_type ||= ::Asciidoctor::Image.image_type image_path
     # handle case when image is a URI
     if (node.is_uri? image_path) || (imagesdir && (node.is_uri? imagesdir) &&

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -423,13 +423,10 @@ class Converter < ::Prawn::Document
     valid_own_icon = false
     if !icons        
         iconsdir = node.attr 'iconsdir'
-        iconname = node.attr 'icon'
-        if iconname.nil? or iconname.blank?
-            iconname = (node.attr 'name')+ ".png"
-        end
         valid_own_icon = true
-        unless (image_path = resolve_image_path node, iconname, nil, true) && (::File.readable? iconsdir)
-            warn %(asciidoctor: WARNING: image to embed not found or not readable: #{iconsdir || iconname}) unless scratch?
+        image_path = node.icon_uri node.attr 'name'
+        unless (image_path) && (::File.readable? iconsdir)
+            warn %(asciidoctor: WARNING: image to embed not found or not readable: #{image_path}) unless scratch?
             valid_own_icon = false
         end                 
     end
@@ -2438,14 +2435,6 @@ class Converter < ::Prawn::Document
     end
   end
   
-  def resolve_iconsdir doc
-    if (iconsdir = doc.attr 'iconsdir').nil_or_empty? || (iconsdir = iconsdir.chomp '/') == '.'
-      nil
-    else
-      %(#{iconsdir}/)
-    end
-  end
-
   # Resolve the system path of the specified image path.
   #
   # Resolve and normalize the absolute system path of the specified image,
@@ -2459,20 +2448,13 @@ class Converter < ::Prawn::Document
   # is not set, or the URI cannot be read, this method returns a nil value.
   #
   # When a temporary file is used, the TemporaryPath type is mixed into the path string.
-  def resolve_image_path node, image_path = nil, image_type = nil, icon = false
-    if icon
-        img_dir = resolve_iconsdir(doc = node.document)
-        if img_dir.nil? or img_dir.blank?
-            img_dir = resolve_imagesdir(doc = node.document)
-        end
-    else
-        img_dir = resolve_imagesdir(doc = node.document)
-    end
-    image_path ||= (node.attr 'target', nil, false)
+  def resolve_image_path node, image_path = nil, image_type = nil
+    imagesdir = resolve_imagesdir(doc = node.document)
+    image_path ||= node.attr 'target'    
     image_type ||= ::Asciidoctor::Image.image_type image_path
     # handle case when image is a URI
-    if (node.is_uri? image_path) || (img_dir && (node.is_uri? img_dir) &&
-        (image_path = (node.normalize_web_path image_path, img_dir, false)))
+    if (node.is_uri? image_path) || (imagesdir && (node.is_uri? imagesdir) &&
+        (image_path = (node.normalize_web_path image_path, imagesdir, false)))
       unless doc.attr? 'allow-uri-read'
         unless scratch?
           warn %(asciidoctor: WARNING: allow-uri-read is not enabled; cannot embed remote image: #{image_path})
@@ -2498,7 +2480,7 @@ class Converter < ::Prawn::Document
       tmp_image_path
     # handle case when image is a local file
     else
-      ::File.expand_path(node.normalize_system_path image_path, img_dir, nil, target_name: 'image')
+      ::File.expand_path(node.normalize_system_path image_path, imagesdir, nil, target_name: 'image')
     end
   end
 

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -2471,8 +2471,8 @@ class Converter < ::Prawn::Document
     image_path ||= (node.attr 'target', nil, false)
     image_type ||= ::Asciidoctor::Image.image_type image_path
     # handle case when image is a URI
-    if (node.is_uri? image_path) || (imagesdir && (node.is_uri? imagesdir) &&
-        (image_path = (node.normalize_web_path image_path, imagesdir, false)))
+    if (node.is_uri? image_path) || (img_dir && (node.is_uri? img_dir) &&
+        (image_path = (node.normalize_web_path image_path, img_dir, false)))
       unless doc.attr? 'allow-uri-read'
         unless scratch?
           warn %(asciidoctor: WARNING: allow-uri-read is not enabled; cannot embed remote image: #{image_path})
@@ -2498,7 +2498,7 @@ class Converter < ::Prawn::Document
       tmp_image_path
     # handle case when image is a local file
     else
-      ::File.expand_path(node.normalize_system_path image_path, imagesdir, nil, target_name: 'image')
+      ::File.expand_path(node.normalize_system_path image_path, img_dir, nil, target_name: 'image')
     end
   end
 

--- a/lib/asciidoctor-pdf/formatted_text/transform.rb
+++ b/lib/asciidoctor-pdf/formatted_text/transform.rb
@@ -15,12 +15,12 @@ class Transform
 
   def initialize(options = {})
     @merge_adjacent_text_nodes = options[:merge_adjacent_text_nodes]
-    if (theme = options[:theme])
-      @link_font_color = theme.link_font_color
-      @monospaced_font_color = theme.literal_font_color
-      @monospaced_font_family = theme.literal_font_family
-      @monospaced_font_size = theme.literal_font_size
-      case theme.literal_font_style
+    if (@theme = options[:theme])
+      @link_font_color = @theme.link_font_color
+      @monospaced_font_color = @theme.literal_font_color
+      @monospaced_font_family = @theme.literal_font_family
+      @monospaced_font_size = @theme.literal_font_size
+      case @theme.literal_font_style
       when 'bold'
         @monospaced_font_style = [:bold]
       when 'italic'
@@ -209,6 +209,21 @@ class Transform
     when :del
       styles << :strikethrough
     when :span
+      if (!attrs[:class].nil? and attrs[:class] != '')
+        pvalue = attrs[:class]
+        if pvalue.start_with? '#'
+          # hexa color code
+          pvalue = pvalue[1..-1] 
+        else
+          # color name -> get color code in the theme file (yaml)             
+          # (I deliberately add suffix _color)
+          pvalue = @theme[%(#{pvalue}_color)]
+          if pvalue.nil? or pvalue == ''
+            pvalue = '000000'
+          end
+        end
+        fragment[:color] = pvalue           
+      end
       # span logic with normal style parsing
       if (inline_styles = attrs[:style])
         # NOTE for our purposes, spaces inside the style attribute are superfluous


### PR DESCRIPTION
Allows to use the same color syntax ( `[red]#my text#` ) to convert asciidoc into HTML or PDF.
The color code  is defined in th eyaml file like `red_color: ff0000`
